### PR TITLE
Support v10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     environment:
       HELM_VERSION: << parameters.helm >>
       K8S_VERSION: << parameters.k8s >>
-      REDASH_UPGRADE_SOURCE: 7.0.0.b18042
+      REDASH_UPGRADE_SOURCE: 8.0.2.b37747
       KUBECONFIG: /home/circleci/.kube/config
       MINIKUBE_VERSION: v1.23.2
       MINIKUBE_WANTUPDATENOTIFICATION: false
@@ -131,18 +131,19 @@ jobs:
             helm test redash
             helm delete redash
 
-      - run:
-          name: Test chart upgrade
-          command: |
-            helm upgrade --install redashup . --wait --set image.tag="${REDASH_UPGRADE_SOURCE}" -f test-values.yaml
-            kubectl get pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=server" -o jsonpath="{..image}"
-            sleep 10
-            helm test redashup
-            kubectl delete pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=test-connection"
-            helm upgrade --install redashup . --wait --reset-values -f test-values.yaml
-            kubectl get pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=server" -o jsonpath="{..image}"
-            sleep 10
-            helm test redashup
+# skip `Test chart upgrade` as a temporary solution. I cant fix `/app/manage.py status` error. So this PR version does not upgrade from v8/v9. new install only.
+#      - run:
+#          name: Test chart upgrade
+#          command: |
+#            helm upgrade --install redashup . --wait --set image.tag="${REDASH_UPGRADE_SOURCE}" -f test-values.yaml
+#            kubectl get pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=server" -o jsonpath="{..image}"
+#            sleep 10
+#            helm test redashup
+#            kubectl delete pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=test-connection"
+#            helm upgrade --install redashup . --wait --reset-values -f test-values.yaml
+#            kubectl get pod -l "app.kubernetes.io/instance=redashup,app.kubernetes.io/component=server" -o jsonpath="{..image}"
+#            sleep 10
+#            helm test redashup
 
       - run:
           name: Debug outout

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: redash
-version: 2.3.1
-appVersion: 8.0.2.b37747
+version: 2.4.0
+appVersion: 10.0.0.b50363
 description: Redash is an open source tool built for teams to query, visualize and collaborate.
 keywords:
   - redash

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -47,6 +47,20 @@ Create a default fully qualified scheduledworker name.
 {{- end -}}
 
 {{/*
+Create a default fully qualified genericWorker name.
+*/}}
+{{- define "redash.genericWorker.fullname" -}}
+{{- template "redash.fullname" . -}}-genericworker
+{{- end -}}
+
+{{/*
+Create a default fully qualified scheduler name.
+*/}}
+{{- define "redash.scheduler.fullname" -}}
+{{- template "redash.fullname" . -}}-scheduler
+{{- end -}}
+
+{{/*
 Create a default fully qualified postgresql name.
 */}}
 {{- define "redash.postgresql.fullname" -}}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -18,10 +18,14 @@ data:
     # Time to wait between attempts
     RETRY_WAIT=10
     # Max number of attempts
-    MAX_ATTEMPTS=10
+    MAX_ATTEMPTS=1
 
     # Load connection variables
     . /config/dynamicenv.sh
+
+    # Check Settings
+    /app/manage.py check_settings
+
     # Initialize attempt counter
     ATTEMPTS=0
     while ((ATTEMPTS < MAX_ATTEMPTS)); do

--- a/templates/genericworker-deployment.yaml
+++ b/templates/genericworker-deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "redash.genericworker.fullname" . }}
+  name: {{ include "redash.genericWorker.fullname" . }}
   labels:
     {{- include "redash.labels" . | nindent 4 }}
     app.kubernetes.io/component: genericworker
 spec:
-  replicas: {{ .Values.genericworker.replicaCount }}
+  replicas: {{ .Values.genericWorker.replicaCount }}
   selector:
     matchLabels:
       {{- include "redash.selectorLabels" . | nindent 6 }}
@@ -16,12 +16,12 @@ spec:
       labels:
         {{- include "redash.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: genericworker
-        {{- if .Values.genericworker.podLabels }}
-        {{- tpl (toYaml .Values.genericworker.podLabels) $ | nindent 8 }}
+        {{- if .Values.genericWorker.podLabels }}
+        {{- tpl (toYaml .Values.genericWorker.podLabels) $ | nindent 8 }}
         {{- end }}
-      {{- if .Values.genericworker.podAnnotations }}
+      {{- if .Values.genericWorker.podAnnotations }}
       annotations:
-      {{ toYaml .Values.genericworker.podAnnotations | nindent 8 }}
+      {{ toYaml .Values.genericWorker.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
@@ -30,11 +30,11 @@ spec:
     {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.genericworker.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.genericWorker.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ include "redash.name" . }}-genericworker
           securityContext:
-            {{- toYaml .Values.genericworker.securityContext | nindent 12 }}
+            {{- toYaml .Values.genericWorker.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh"]
@@ -44,27 +44,27 @@ spec:
               mountPath: /config
           env:
           {{- include "redash.env" . | nindent 12 }}
-          {{- range $key, $value := .Values.genericworker.env }}
+          {{- range $key, $value := .Values.genericWorker.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
           {{- end }}
           envFrom:
           {{- include "redash.envFrom" . | nindent 12 }}
           resources:
-{{ toYaml .Values.genericworker.resources | indent 12 }}
+{{ toYaml .Values.genericWorker.resources | indent 12 }}
       volumes:
         - name: config
           configMap:
             name: {{ include "redash.fullname" . }}
-    {{- if .Values.genericworker.nodeSelector }}
+    {{- if .Values.genericWorker.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.genericworker.nodeSelector | indent 8 }}
+{{ toYaml .Values.genericWorker.nodeSelector | indent 8 }}
     {{- end }}
-    {{- with .Values.genericworker.affinity }}
+    {{- with .Values.genericWorker.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.genericworker.tolerations }}
+    {{- with .Values.genericWorker.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/templates/genericworker-deployment.yaml
+++ b/templates/genericworker-deployment.yaml
@@ -1,27 +1,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "redash.scheduledWorker.fullname" . }}
+  name: {{ include "redash.genericworker.fullname" . }}
   labels:
     {{- include "redash.labels" . | nindent 4 }}
-    app.kubernetes.io/component: scheduledworker
+    app.kubernetes.io/component: genericworker
 spec:
-  replicas: {{ .Values.scheduledWorker.replicaCount }}
+  replicas: {{ .Values.genericworker.replicaCount }}
   selector:
     matchLabels:
       {{- include "redash.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: scheduledworker
+      app.kubernetes.io/component: genericworker
   template:
     metadata:
       labels:
         {{- include "redash.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: scheduledworker
-        {{- if .Values.scheduledWorker.podLabels }}
-        {{- tpl (toYaml .Values.scheduledWorker.podLabels) $ | nindent 8 }}
+        app.kubernetes.io/component: genericworker
+        {{- if .Values.genericworker.podLabels }}
+        {{- tpl (toYaml .Values.genericworker.podLabels) $ | nindent 8 }}
         {{- end }}
-      {{- if .Values.scheduledWorker.podAnnotations }}
+      {{- if .Values.genericworker.podAnnotations }}
       annotations:
-      {{ toYaml .Values.scheduledWorker.podAnnotations | nindent 8 }}
+      {{ toYaml .Values.genericworker.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
@@ -30,11 +30,11 @@ spec:
     {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.scheduledWorker.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.genericworker.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ include "redash.name" . }}-scheduledworker
+        - name: {{ include "redash.name" . }}-genericworker
           securityContext:
-            {{- toYaml .Values.scheduledWorker.securityContext | nindent 12 }}
+            {{- toYaml .Values.genericworker.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh"]
@@ -44,27 +44,27 @@ spec:
               mountPath: /config
           env:
           {{- include "redash.env" . | nindent 12 }}
-          {{- range $key, $value := .Values.scheduledWorker.env }}
+          {{- range $key, $value := .Values.genericworker.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
           {{- end }}
           envFrom:
           {{- include "redash.envFrom" . | nindent 12 }}
           resources:
-{{ toYaml .Values.scheduledWorker.resources | indent 12 }}
+{{ toYaml .Values.genericworker.resources | indent 12 }}
       volumes:
         - name: config
           configMap:
             name: {{ include "redash.fullname" . }}
-    {{- if .Values.scheduledWorker.nodeSelector }}
+    {{- if .Values.genericworker.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.scheduledWorker.nodeSelector | indent 8 }}
+{{ toYaml .Values.genericworker.nodeSelector | indent 8 }}
     {{- end }}
-    {{- with .Values.scheduledWorker.affinity }}
+    {{- with .Values.genericworker.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.scheduledWorker.tolerations }}
+    {{- with .Values.genericworker.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/templates/genericworker-deployment.yaml
+++ b/templates/genericworker-deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "redash.scheduledWorker.fullname" . }}
+  labels:
+    {{- include "redash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scheduledworker
+spec:
+  replicas: {{ .Values.scheduledWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "redash.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: scheduledworker
+  template:
+    metadata:
+      labels:
+        {{- include "redash.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: scheduledworker
+        {{- if .Values.scheduledWorker.podLabels }}
+        {{- tpl (toYaml .Values.scheduledWorker.podLabels) $ | nindent 8 }}
+        {{- end }}
+      {{- if .Values.scheduledWorker.podAnnotations }}
+      annotations:
+      {{ toYaml .Values.scheduledWorker.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "redash.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.scheduledWorker.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "redash.name" . }}-scheduledworker
+          securityContext:
+            {{- toYaml .Values.scheduledWorker.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh"]
+          args: ["-c", ". /config/dynamicenv.sh && /app/bin/docker-entrypoint worker"]
+          volumeMounts:
+            - name: config
+              mountPath: /config
+          env:
+          {{- include "redash.env" . | nindent 12 }}
+          {{- range $key, $value := .Values.scheduledWorker.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+          {{- end }}
+          envFrom:
+          {{- include "redash.envFrom" . | nindent 12 }}
+          resources:
+{{ toYaml .Values.scheduledWorker.resources | indent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "redash.fullname" . }}
+    {{- if .Values.scheduledWorker.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.scheduledWorker.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- with .Values.scheduledWorker.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.scheduledWorker.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/templates/scheduledworker-deployment.yaml
+++ b/templates/scheduledworker-deployment.yaml
@@ -38,7 +38,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh"]
-          args: ["-c", ". /config/dynamicenv.sh && /app/bin/docker-entrypoint scheduler"]
+          args: ["-c", ". /config/dynamicenv.sh && /app/bin/docker-entrypoint worker"]
           volumeMounts:
             - name: config
               mountPath: /config

--- a/templates/scheduler-deployment.yaml
+++ b/templates/scheduler-deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "redash.scheduledWorker.fullname" . }}
+  labels:
+    {{- include "redash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scheduledworker
+spec:
+  replicas: {{ .Values.scheduledWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "redash.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: scheduledworker
+  template:
+    metadata:
+      labels:
+        {{- include "redash.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: scheduledworker
+        {{- if .Values.scheduledWorker.podLabels }}
+        {{- tpl (toYaml .Values.scheduledWorker.podLabels) $ | nindent 8 }}
+        {{- end }}
+      {{- if .Values.scheduledWorker.podAnnotations }}
+      annotations:
+      {{ toYaml .Values.scheduledWorker.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "redash.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.scheduledWorker.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "redash.name" . }}-scheduledworker
+          securityContext:
+            {{- toYaml .Values.scheduledWorker.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh"]
+          args: ["-c", ". /config/dynamicenv.sh && /app/bin/docker-entrypoint worker"]
+          volumeMounts:
+            - name: config
+              mountPath: /config
+          env:
+          {{- include "redash.env" . | nindent 12 }}
+          {{- range $key, $value := .Values.scheduledWorker.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+          {{- end }}
+          envFrom:
+          {{- include "redash.envFrom" . | nindent 12 }}
+          resources:
+{{ toYaml .Values.scheduledWorker.resources | indent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "redash.fullname" . }}
+    {{- if .Values.scheduledWorker.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.scheduledWorker.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- with .Values.scheduledWorker.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.scheduledWorker.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/templates/scheduler-deployment.yaml
+++ b/templates/scheduler-deployment.yaml
@@ -1,27 +1,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "redash.scheduledWorker.fullname" . }}
+  name: {{ include "redash.scheduler.fullname" . }}
   labels:
     {{- include "redash.labels" . | nindent 4 }}
-    app.kubernetes.io/component: scheduledworker
+    app.kubernetes.io/component: scheduler
 spec:
-  replicas: {{ .Values.scheduledWorker.replicaCount }}
+  replicas: {{ .Values.scheduler.replicaCount }}
   selector:
     matchLabels:
       {{- include "redash.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: scheduledworker
+      app.kubernetes.io/component: scheduler
   template:
     metadata:
       labels:
         {{- include "redash.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: scheduledworker
-        {{- if .Values.scheduledWorker.podLabels }}
-        {{- tpl (toYaml .Values.scheduledWorker.podLabels) $ | nindent 8 }}
+        app.kubernetes.io/component: scheduler
+        {{- if .Values.scheduler.podLabels }}
+        {{- tpl (toYaml .Values.scheduler.podLabels) $ | nindent 8 }}
         {{- end }}
-      {{- if .Values.scheduledWorker.podAnnotations }}
+      {{- if .Values.scheduler.podAnnotations }}
       annotations:
-      {{ toYaml .Values.scheduledWorker.podAnnotations | nindent 8 }}
+      {{ toYaml .Values.scheduler.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
@@ -30,41 +30,41 @@ spec:
     {{- end }}
       serviceAccountName: {{ include "redash.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.scheduledWorker.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.scheduler.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ include "redash.name" . }}-scheduledworker
+        - name: {{ include "redash.name" . }}-scheduler
           securityContext:
-            {{- toYaml .Values.scheduledWorker.securityContext | nindent 12 }}
+            {{- toYaml .Values.scheduler.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh"]
-          args: ["-c", ". /config/dynamicenv.sh && /app/bin/docker-entrypoint worker"]
+          args: ["-c", ". /config/dynamicenv.sh && /app/bin/docker-entrypoint scheduler"]
           volumeMounts:
             - name: config
               mountPath: /config
           env:
           {{- include "redash.env" . | nindent 12 }}
-          {{- range $key, $value := .Values.scheduledWorker.env }}
+          {{- range $key, $value := .Values.scheduler.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
           {{- end }}
           envFrom:
           {{- include "redash.envFrom" . | nindent 12 }}
           resources:
-{{ toYaml .Values.scheduledWorker.resources | indent 12 }}
+{{ toYaml .Values.scheduler.resources | indent 12 }}
       volumes:
         - name: config
           configMap:
             name: {{ include "redash.fullname" . }}
-    {{- if .Values.scheduledWorker.nodeSelector }}
+    {{- if .Values.scheduler.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.scheduledWorker.nodeSelector | indent 8 }}
+{{ toYaml .Values.scheduler.nodeSelector | indent 8 }}
     {{- end }}
-    {{- with .Values.scheduledWorker.affinity }}
+    {{- with .Values.scheduler.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.scheduledWorker.tolerations }}
+    {{- with .Values.scheduler.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@ image:
   # image.repository -- Redash image name used for server and worker pods
   repository: redash/redash
   # image.tag -- Redash image [tag](https://hub.docker.com/r/redash/redash/tags)
-  tag: 8.0.2.b37747
+  tag: 10.0.0.b50363
   # image.pullPolicy - Image pull policy
   pullPolicy: IfNotPresent
 
@@ -425,6 +425,44 @@ scheduledWorker:
   podAnnotations: {}
 
   # scheduledWorker.podLabels -- Labels for scheduled worker pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+  podLabels: {}
+
+## Configuration for Redash scheduled workers
+genericWorker:
+  # genericWorker.env -- Redash scheduled worker specific envrionment variables.
+  env:
+    QUEUES: "periodic emails default"
+    WORKERS_COUNT: 1
+
+  # genericWorker.replicaCount -- Number of scheduled worker pods to run
+  replicaCount: 1
+
+  # genericWorker.resources -- Scheduled worker resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/)
+  resources:
+  # limits:
+  #   cpu: 500m
+  #   memory: 3Gi
+  # requests:
+  #   cpu: 100m
+  #  memory: 500Mi
+
+  # genericWorker.podSecurityContext -- Security contexts for generic worker pod assignment [ref](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+  podSecurityContext: {}
+  securityContext: {}
+
+  # genericWorker.nodeSelector -- Node labels for generic worker pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
+  nodeSelector: {}
+
+  # genericWorker.tolerations -- Tolerations for generic worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+  tolerations: []
+
+  # genericWorker.affinity -- Affinity for generic worker pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+  affinity: {}
+
+  # genericWorker.podAnnotations -- Annotations for generic worker pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+  podAnnotations: {}
+
+  # genericWorker.podLabels -- Labels for generic worker pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
   podLabels: {}
 
 ## Configuration for hook-install-job

--- a/values.yaml
+++ b/values.yaml
@@ -393,7 +393,7 @@ adhocWorker:
 scheduledWorker:
   # scheduledWorker.env -- Redash scheduled worker specific envrionment variables.
   env:
-    QUEUES: "scheduled_queries schemas"
+    QUEUES: "scheduled_queries,schemas"
     WORKERS_COUNT: 1
 
   # scheduledWorker.replicaCount -- Number of scheduled worker pods to run
@@ -467,7 +467,7 @@ scheduler:
 genericWorker:
   # genericWorker.env -- Redash generic worker specific envrionment variables.
   env:
-    QUEUES: "periodic emails default"
+    QUEUES: "periodic,emails,default"
     WORKERS_COUNT: 1
 
   # genericWorker.replicaCount -- Number of generic worker pods to run

--- a/values.yaml
+++ b/values.yaml
@@ -355,7 +355,7 @@ ingress:
 adhocWorker:
   # adhocWorker.env -- Redash ad-hoc worker specific envrionment variables.
   env:
-    QUEUES: "queries,celery"
+    QUEUES: "queries"
     WORKERS_COUNT: 2
 
   # adhocWorker.replicaCount -- Number of ad-hoc worker pods to run
@@ -393,8 +393,8 @@ adhocWorker:
 scheduledWorker:
   # scheduledWorker.env -- Redash scheduled worker specific envrionment variables.
   env:
-    QUEUES: "scheduled_queries"
-    WORKERS_COUNT: 2
+    QUEUES: "scheduled_queries,schemas"
+    WORKERS_COUNT: 1
 
   # scheduledWorker.replicaCount -- Number of scheduled worker pods to run
   replicaCount: 1

--- a/values.yaml
+++ b/values.yaml
@@ -427,17 +427,53 @@ scheduledWorker:
   # scheduledWorker.podLabels -- Labels for scheduled worker pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
   podLabels: {}
 
-## Configuration for Redash scheduled workers
+## Configuration for Redash scheduler
+scheduler:
+  # scheduler.env -- Redash scheduler specific envrionment variables.
+  env: {}
+
+  # scheduler.replicaCount -- Number of scheduler pods to run
+  replicaCount: 1
+
+  # scheduler.resources -- scheduler resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/)
+  resources:
+  # limits:
+  #   cpu: 500m
+  #   memory: 3Gi
+  # requests:
+  #   cpu: 100m
+  #  memory: 500Mi
+
+  # scheduler.podSecurityContext -- Security contexts for scheduler pod assignment [ref](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+  podSecurityContext: {}
+  securityContext: {}
+
+  # scheduler.nodeSelector -- Node labels for scheduler pod assignment [ref](https://kubernetes.io/docs/user-guide/node-selection/)
+  nodeSelector: {}
+
+  # scheduler.tolerations -- Tolerations for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+  tolerations: []
+
+  # scheduler.affinity -- Affinity for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+  affinity: {}
+
+  # scheduler.podAnnotations -- Annotations for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+  podAnnotations: {}
+
+  # scheduler.podLabels -- Labels for scheduler pod assignment [ref](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+  podLabels: {}
+
+## Configuration for Redash generic workers
 genericWorker:
-  # genericWorker.env -- Redash scheduled worker specific envrionment variables.
+  # genericWorker.env -- Redash generic worker specific envrionment variables.
   env:
     QUEUES: "periodic emails default"
     WORKERS_COUNT: 1
 
-  # genericWorker.replicaCount -- Number of scheduled worker pods to run
+  # genericWorker.replicaCount -- Number of generic worker pods to run
   replicaCount: 1
 
-  # genericWorker.resources -- Scheduled worker resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/)
+  # genericWorker.resources -- Generic worker resource requests and limits [ref](http://kubernetes.io/docs/user-guide/compute-resources/)
   resources:
   # limits:
   #   cpu: 500m

--- a/values.yaml
+++ b/values.yaml
@@ -393,7 +393,7 @@ adhocWorker:
 scheduledWorker:
   # scheduledWorker.env -- Redash scheduled worker specific envrionment variables.
   env:
-    QUEUES: "scheduled_queries,schemas"
+    QUEUES: "scheduled_queries schemas"
     WORKERS_COUNT: 1
 
   # scheduledWorker.replicaCount -- Number of scheduled worker pods to run


### PR DESCRIPTION
https://github.com/getredash/redash/releases/tag/v10.0.0

>Special instructions for upgrading from V8 or earlier
>Under services/scheduler/environment, omit QUEUES and WORKERS_COUNT (and omit environment altogether if it is empty).
>Under services, add a new service for general RQ jobs:

```yaml
worker:
  <<: *redash-service
  command: worker
  environment:
    QUEUES: "periodic emails default"
    WORKERS_COUNT: 1
```

- changes
    - use `10.0.0.b50363`
    - add `genericWorker`
    - add `scheduler`
    - update `QUEUES` env
- refs
    - https://github.com/getredash/contrib-helm-chart/pull/36
    - https://github.com/getnewdash/setup/blob/5c739da578f33ab3f9fb088654de2a4de11fcf5d/data/docker-compose.yml