### PR TITLE
update ingress

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -29,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Ingress spec is different when you compare the API version of `networking.k8s.io/v1beta` against `networking.k8s.io/v1`
Please refer to https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122